### PR TITLE
feat(errors): padroniza respostas de erro e documentação Swagger

### DIFF
--- a/src/association/association.controller.ts
+++ b/src/association/association.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
-import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiNotFoundResponse, ApiQuery, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ErrorResponseDto, ValidationErrorResponseDto } from 'src/common/dto/error-response.dto';
 import { AssociationService } from './association.service';
 import { CreateAssociationDto } from './dto/create-association.dto';
 import { UpdateAssociationDto } from './dto/update-association.dto';
@@ -12,11 +13,15 @@ export class AssociationController {
   constructor(private readonly associationService: AssociationService) {}
 
   @Post()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
   create(@Body() createAssociationDto: CreateAssociationDto) {
     return this.associationService.create(createAssociationDto);
   }
 
   @Get()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Parâmetros de consulta inválidos', type: ValidationErrorResponseDto })
   @ApiQuery({ name: 'name', required: false, type: String, description: 'Filtro por nome (contém)' })
   @ApiQuery({ name: 'cnpj', required: false, type: String, description: 'Filtro por CNPJ (contém)' })
   @ApiQuery({ name: 'status', required: false, type: Boolean, description: 'Filtrar por status' })
@@ -29,21 +34,28 @@ export class AssociationController {
   }
 
   @Get('id/:id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Associação não encontrada', type: ErrorResponseDto })
   findOneById(@Param('id') id: string) {
     return this.associationService.findOneById(id);
   }
 
   @Get('cnpj/:cnpj')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Associação não encontrada', type: ErrorResponseDto })
   findOneCnpj(@Param('cnpj') cnpj: string) {
     return this.associationService.findOneByCnpj(cnpj);
   }
 
   @Patch(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
   update(@Param('id') id: string, @Body() updateAssociationDto: UpdateAssociationDto) {
     return this.associationService.update(id, updateAssociationDto);
   }
 
   @Delete(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   remove(@Param('id') id: string) {
     return this.associationService.remove(id);
   }

--- a/src/association/association.service.ts
+++ b/src/association/association.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateAssociationDto } from './dto/create-association.dto';
 import { UpdateAssociationDto } from './dto/update-association.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -35,16 +35,16 @@ export class AssociationService {
     return { items, total, page: page ?? 1, limit: take, pageCount }
   }
 
-  findOneById(id: string) {
-    return this.repo.findOneBy({
-      id
-    })
+  async findOneById(id: string) {
+    const association = await this.repo.findOneBy({ id })
+    if (!association) throw new NotFoundException('Associação não encontrada')
+    return association
   }
 
-  findOneByCnpj(cnpj: string) {
-    return this.repo.findOneBy({
-      cnpj
-    })
+  async findOneByCnpj(cnpj: string) {
+    const association = await this.repo.findOneBy({ cnpj })
+    if (!association) throw new NotFoundException('Associação não encontrada')
+    return association
   }
 
   update(id: string, updateAssociationDto: UpdateAssociationDto) {

--- a/src/association/dto/query-association.dto.ts
+++ b/src/association/dto/query-association.dto.ts
@@ -5,26 +5,26 @@ import { ApiPropertyOptional } from '@nestjs/swagger'
 export class QueryAssociationDto extends PaginationQueryDto {
   @ApiPropertyOptional({ description: 'Filtro por nome (contém)', example: 'Bairro' })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'name deve ser uma string' })
   name?: string
 
   @ApiPropertyOptional({ description: 'Filtro por CNPJ (contém)', example: '12.345' })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'cnpj deve ser uma string' })
   cnpj?: string
 
   @ApiPropertyOptional({ description: 'Filtrar por status', example: 'true' })
   @IsOptional()
-  @IsBooleanString()
+  @IsBooleanString({ message: "status deve ser 'true' ou 'false'" })
   status?: string
 
   @ApiPropertyOptional({ description: 'Campo para ordenação', enum: ['id', 'name', 'cnpj', 'status'], default: 'id' })
   @IsOptional()
-  @IsIn(['id', 'name', 'cnpj', 'status'])
+  @IsIn(['id', 'name', 'cnpj', 'status'], { message: "sortBy inválido. Permitidos: 'id', 'name', 'cnpj', 'status'" })
   sortBy?: 'id' | 'name' | 'cnpj' | 'status' = 'id'
 
   @ApiPropertyOptional({ description: 'Direção da ordenação', enum: ['ASC', 'DESC'], default: 'ASC' })
   @IsOptional()
-  @IsIn(['ASC', 'DESC', 'asc', 'desc'])
+  @IsIn(['ASC', 'DESC', 'asc', 'desc'], { message: "sortOrder inválido. Permitidos: 'ASC', 'DESC', 'asc', 'desc'" })
   sortOrder?: 'ASC' | 'DESC' | 'asc' | 'desc' = 'ASC'
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Post, Body } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { CreateAuthDto } from './dto/login-auth.dto';
 import { Public } from './public.decorator';
+import { ErrorResponseDto, ValidationErrorResponseDto } from 'src/common/dto/error-response.dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -11,6 +12,8 @@ export class AuthController {
 
   @Public()
   @Post('login')
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Login local desativado', type: ErrorResponseDto })
   login(@Body() dto: CreateAuthDto) {
     return this.authService.login(dto)
   }

--- a/src/common/dto/error-response.dto.ts
+++ b/src/common/dto/error-response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class ErrorResponseDto {
+  @ApiProperty({ example: 401, description: 'Código HTTP do erro' })
+  statusCode: number
+
+  @ApiProperty({ example: 'UNAUTHORIZED', description: 'Código interno padronizado do erro' })
+  code: string
+
+  @ApiProperty({ example: 'Não autenticado', description: 'Mensagem de erro legível' })
+  message: string
+
+  @ApiProperty({ example: '/task', description: 'Caminho da requisição' })
+  path: string
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z', description: 'Timestamp do erro' })
+  timestamp: string
+}
+
+export class ValidationErrorResponseDto extends ErrorResponseDto {
+  @ApiProperty({
+    example: [
+      'title deve ser uma string',
+      "status inválido. Valores permitidos: open, inProgress, finished, canceled",
+    ],
+    description: 'Lista de mensagens de validação',
+  })
+  details: string[]
+}
+

--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -6,15 +6,15 @@ export class PaginationQueryDto {
   @ApiPropertyOptional({ description: 'Página atual', example: 1, minimum: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
-  @IsInt()
-  @Min(1)
+  @IsInt({ message: 'Página deve ser um número inteiro' })
+  @Min(1, { message: 'Página mínima é 1' })
   page?: number = 1
 
   @ApiPropertyOptional({ description: 'Itens por página', example: 10, minimum: 1, maximum: 100, default: 10 })
   @IsOptional()
   @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(100)
+  @IsInt({ message: 'Itens por página deve ser um número inteiro' })
+  @Min(1, { message: 'Itens por página mínimo é 1' })
+  @Max(100, { message: 'Itens por página máximo é 100' })
   limit?: number = 10
 }

--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,71 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common'
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse()
+    const request = ctx.getRequest()
+
+    const timestamp = new Date().toISOString()
+    const path = request?.url
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus()
+      const res: any = exception.getResponse()
+
+      // Validation Pipe errors usually send: { statusCode, message: string[], error }
+      const isValidation = status === HttpStatus.BAD_REQUEST && Array.isArray(res?.message)
+
+      const body = isValidation
+        ? {
+            statusCode: status,
+            code: 'VALIDATION_ERROR',
+            message: 'Erro de validação',
+            details: res.message,
+            path,
+            timestamp,
+          }
+        : {
+            statusCode: status,
+            code: this.mapHttpCode(exception),
+            message: typeof res === 'string' ? res : res?.message ?? exception.message,
+            path,
+            timestamp,
+          }
+
+      return response.status(status).json(body)
+    }
+
+    // Unknown error
+    const status = HttpStatus.INTERNAL_SERVER_ERROR
+    return response.status(status).json({
+      statusCode: status,
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Erro interno do servidor',
+      path,
+      timestamp,
+    })
+  }
+
+  private mapHttpCode(exception: HttpException): string {
+    const name = exception.constructor.name
+    switch (name) {
+      case 'BadRequestException':
+        return 'BAD_REQUEST'
+      case 'UnauthorizedException':
+        return 'UNAUTHORIZED'
+      case 'ForbiddenException':
+        return 'FORBIDDEN'
+      case 'NotFoundException':
+        return 'NOT_FOUND'
+      case 'ConflictException':
+        return 'CONFLICT'
+      case 'UnprocessableEntityException':
+        return 'UNPROCESSABLE_ENTITY'
+      default:
+        return 'HTTP_ERROR'
+    }
+  }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -12,6 +13,7 @@ async function bootstrap() {
   stopAtFirstError: true,
   transform: true,
 }));
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   const config = new DocumentBuilder()
     .setTitle('API - Tarefa Associada')

--- a/src/meta/meta.controller.ts
+++ b/src/meta/meta.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ErrorResponseDto } from 'src/common/dto/error-response.dto';
 import { TaskStatus } from 'src/task/entities/task.entity';
 import { UserRole } from 'src/user/entities/user.entity';
 
@@ -8,6 +9,7 @@ import { UserRole } from 'src/user/entities/user.entity';
 @Controller('meta')
 export class MetaController {
   @Get('enums/user-roles')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista de valores do enum UserRole',
     schema: { type: 'array', items: { type: 'string', enum: Object.values(UserRole) } },
@@ -17,6 +19,7 @@ export class MetaController {
   }
 
   @Get('enums/task-status')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista de valores do enum TaskStatus',
     schema: { type: 'array', items: { type: 'string', enum: Object.values(TaskStatus) } },
@@ -26,6 +29,7 @@ export class MetaController {
   }
 
   @Get('enums')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Objeto com listas dos enums usados nos selects',
     schema: {
@@ -43,4 +47,3 @@ export class MetaController {
     };
   }
 }
-

--- a/src/task/dto/query-task.dto.ts
+++ b/src/task/dto/query-task.dto.ts
@@ -6,26 +6,26 @@ import { ApiPropertyOptional } from '@nestjs/swagger'
 export class QueryTaskDto extends PaginationQueryDto {
   @ApiPropertyOptional({ description: 'Filtro por título (contém)', example: 'reunião' })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'title deve ser uma string' })
   title?: string
 
   @ApiPropertyOptional({ description: 'Filtrar por status', enum: TaskStatus, example: 'open' })
   @IsOptional()
-  @IsIn(Object.values(TaskStatus))
+  @IsIn(Object.values(TaskStatus), { message: `status inválido. Permitidos: ${Object.values(TaskStatus).join(', ')}` })
   status?: TaskStatus
 
   @ApiPropertyOptional({ description: 'Filtrar por criador (UUID)', example: '3fa85f64-5717-4562-b3fc-2c963f66afa6' })
   @IsOptional()
-  @IsUUID()
+  @IsUUID('4', { message: 'creatorId deve ser um UUID v4 válido' })
   creatorId?: string
 
   @ApiPropertyOptional({ description: 'Campo para ordenação', enum: ['id', 'title', 'status'], default: 'id' })
   @IsOptional()
-  @IsIn(['id', 'title', 'status'])
+  @IsIn(['id', 'title', 'status'], { message: "sortBy inválido. Permitidos: 'id', 'title', 'status'" })
   sortBy?: 'id' | 'title' | 'status' = 'id'
 
   @ApiPropertyOptional({ description: 'Direção da ordenação', enum: ['ASC', 'DESC'], default: 'ASC' })
   @IsOptional()
-  @IsIn(['ASC', 'DESC', 'asc', 'desc'])
+  @IsIn(['ASC', 'DESC', 'asc', 'desc'], { message: "sortOrder inválido. Permitidos: 'ASC', 'DESC', 'asc', 'desc'" })
   sortOrder?: 'ASC' | 'DESC' | 'asc' | 'desc' = 'ASC'
 }

--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiNotFoundResponse, ApiOkResponse, ApiQuery, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ErrorResponseDto, ValidationErrorResponseDto } from 'src/common/dto/error-response.dto';
 import { TaskService } from './task.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
@@ -12,11 +13,15 @@ export class TaskController {
   constructor(private readonly taskService: TaskService) {}
 
   @Post()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
   create(@Body() createTaskDto: CreateTaskDto) {
     return this.taskService.create(createTaskDto);
   }
 
   @Get()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Parâmetros de consulta inválidos', type: ValidationErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista paginada de tarefas',
     schema: {
@@ -42,16 +47,22 @@ export class TaskController {
   }
 
   @Get(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Tarefa não encontrada', type: ErrorResponseDto })
   findOne(@Param('id') id: string) {
     return this.taskService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Tarefa não encontrada', type: ErrorResponseDto })
   update(@Param('id') id: string, @Body() updateTaskDto: UpdateTaskDto) {
     return this.taskService.update(id, updateTaskDto);
   }
 
   @Delete(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   remove(@Param('id') id: string) {
     return this.taskService.remove(id);
   }

--- a/src/task/task.service.ts
+++ b/src/task/task.service.ts
@@ -52,13 +52,13 @@ export class TaskService {
 
   async findOne(id: string) {
     const task = await this.repo.findOne({ where: { id }, relations: { creator: true, team: true } })
-    if (!task) throw new NotFoundException('Task not found')
+    if (!task) throw new NotFoundException('Tarefa não encontrada')
     return task
   }
 
   async update(id: string, updateTaskDto: UpdateTaskDto) {
     const task = await this.repo.findOne({ where: { id }, relations: { team: true, creator: true } })
-    if (!task) throw new NotFoundException('Task not found')
+    if (!task) throw new NotFoundException('Tarefa não encontrada')
 
     if (typeof updateTaskDto.title !== 'undefined') task.title = updateTaskDto.title
     if (typeof updateTaskDto.description !== 'undefined') task.description = updateTaskDto.description

--- a/src/user/dto/query-user.dto.ts
+++ b/src/user/dto/query-user.dto.ts
@@ -6,26 +6,26 @@ import { ApiPropertyOptional } from '@nestjs/swagger'
 export class QueryUserDto extends PaginationQueryDto {
   @ApiPropertyOptional({ description: 'Filtro por nome (contém)', example: 'Maria' })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'name deve ser uma string' })
   name?: string
 
   @ApiPropertyOptional({ description: 'Filtro por e-mail (contém)', example: 'maria' })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'email deve ser uma string' })
   email?: string
 
   @ApiPropertyOptional({ description: 'Filtrar por papel', enum: UserRole, example: 'admin' })
   @IsOptional()
-  @IsIn(Object.values(UserRole))
+  @IsIn(Object.values(UserRole), { message: `role inválido. Permitidos: ${Object.values(UserRole).join(', ')}` })
   role?: UserRole
 
   @ApiPropertyOptional({ description: 'Campo para ordenação', enum: ['id', 'name', 'email', 'role'], default: 'id' })
   @IsOptional()
-  @IsIn(['id', 'name', 'email', 'role'])
+  @IsIn(['id', 'name', 'email', 'role'], { message: "sortBy inválido. Permitidos: 'id', 'name', 'email', 'role'" })
   sortBy?: 'id' | 'name' | 'email' | 'role' = 'id'
 
   @ApiPropertyOptional({ description: 'Direção da ordenação', enum: ['ASC', 'DESC'], default: 'ASC' })
   @IsOptional()
-  @IsIn(['ASC', 'DESC', 'asc', 'desc'])
+  @IsIn(['ASC', 'DESC', 'asc', 'desc'], { message: "sortOrder inválido. Permitidos: 'ASC', 'DESC', 'asc', 'desc'" })
   sortOrder?: 'ASC' | 'DESC' | 'asc' | 'desc' = 'ASC'
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, Query, Req, UnauthorizedException } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiConflictResponse, ApiNotFoundResponse, ApiOkResponse, ApiQuery, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ErrorResponseDto, ValidationErrorResponseDto } from 'src/common/dto/error-response.dto';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -13,6 +14,9 @@ export class UserController {
   constructor(private readonly userService: UserService) { }
 
   @Post()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
+  @ApiConflictResponse({ description: 'E-mail já em uso', type: ErrorResponseDto })
   create(@Req() req: Request, @Body() createUserDto: CreateUserDto) {
     const { user } = req as any;
     const userId: string = user?.userId;
@@ -24,6 +28,8 @@ export class UserController {
   }
 
   @Get()
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Parâmetros de consulta inválidos', type: ValidationErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista paginada de usuários',
     schema: {
@@ -49,21 +55,31 @@ export class UserController {
   }
 
   @Get('id/:id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Usuário não encontrado', type: ErrorResponseDto })
   findOneById(@Param('id') id: string) {
     return this.userService.findOne(id);
   }
 
   @Get('email/:email')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Usuário não encontrado', type: ErrorResponseDto })
   findOneByEmail(@Param('email') email: string) {
     return this.userService.findOneByEmail(email);
   }
 
   @Patch(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos', type: ValidationErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Usuário não encontrado', type: ErrorResponseDto })
+  @ApiConflictResponse({ description: 'E-mail já em uso', type: ErrorResponseDto })
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.userService.update(id, updateUserDto);
   }
 
   @Delete(':id')
+  @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
+  @ApiNotFoundResponse({ description: 'Usuário não encontrado', type: ErrorResponseDto })
   remove(@Param('id') id: string) {
     return this.userService.remove(id);
   }

--- a/test/association.e2e-spec.ts
+++ b/test/association.e2e-spec.ts
@@ -107,9 +107,12 @@ describe('Association (e2e) - entidade atual e DTOs', () => {
     const del = await request(server).delete(`/association/${id}`).expect(200);
     expect(del.body.affected ?? 1).toBe(1);
 
-    // Após remover, GET não deve retornar o registro (null ou objeto vazio)
-    const afterDel = await request(server).get(`/association/id/${id}`).expect(200);
-    const body = afterDel.body;
-    expect((body && body.id) ?? null).toBeNull();
+    // Após remover, GET deve retornar 404 com payload de erro padronizado
+    const afterDel = await request(server).get(`/association/id/${id}`).expect(404);
+    expect(afterDel.body).toMatchObject({
+      statusCode: 404,
+      code: 'NOT_FOUND',
+      message: 'Associação não encontrada',
+    })
   });
 });

--- a/test/association.e2e-spec.ts
+++ b/test/association.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import request from 'supertest';
+import { AllExceptionsFilter } from '../src/common/filters/all-exceptions.filter';
 import { AssociationModule } from '../src/association/association.module';
 import { Association } from '../src/association/entities/association.entity';
 
@@ -39,6 +40,7 @@ describe('Association (e2e) - entidade atual e DTOs', () => {
         transform: true,
       }),
     );
+    app.useGlobalFilters(new AllExceptionsFilter());
     await app.init();
   });
 


### PR DESCRIPTION
- Cria AllExceptionsFilter com payload padrão (statusCode, code, message, path, timestamp)
- DTOs de erro: ErrorResponseDto e ValidationErrorResponseDto
- Adiciona @Api*Response com tipos de erro em user/task/association/meta/auth
- PT-BR nas mensagens de validação (pagination/query DTOs)
- 404 consistente: Associação e Tarefa com mensagens PT-BR