### PR TITLE
feat(http): habilita CORS, adiciona rotas PT-BR e endpoints publicos

### DIFF
--- a/src/association/association.controller.ts
+++ b/src/association/association.controller.ts
@@ -8,7 +8,7 @@ import { QueryAssociationDto } from './dto/query-association.dto';
 
 @ApiTags('association')
 @ApiBearerAuth('access-token')
-@Controller('association')
+@Controller(['association', 'associacoes'])
 export class AssociationController {
   constructor(private readonly associationService: AssociationService) {}
 
@@ -29,8 +29,13 @@ export class AssociationController {
   @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Itens por página', example: 10 })
   @ApiQuery({ name: 'sortBy', required: false, enum: ['id', 'name', 'cnpj', 'status'], description: 'Campo para ordenação' })
   @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Direção da ordenação' })
-  findAll(@Query() query: QueryAssociationDto) {
-    return this.associationService.findAll(query);
+  findAll(@Query() query: any) {
+    // alias perPage -> limit
+    const q: QueryAssociationDto = { ...query }
+    if (q && (q as any).perPage && !q.limit) {
+      q.limit = Number((q as any).perPage)
+    }
+    return this.associationService.findAll(q);
   }
 
   @Get('id/:id')

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  // Habilita CORS para consumo via frontend (localhost e produção)
+  app.enableCors({ origin: true, credentials: true });
   app.useGlobalPipes(new ValidationPipe({
   whitelist: true,
   forbidNonWhitelisted: true,

--- a/src/meta/enums.controller.ts
+++ b/src/meta/enums.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get } from '@nestjs/common'
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger'
+import { Public } from 'src/auth/public.decorator'
+import { TaskStatus } from 'src/task/entities/task.entity'
+
+@ApiTags('enums')
+@Controller('enums')
+export class EnumsController {
+  @Get('prioridades')
+  @Public()
+  @ApiOkResponse({
+    description: 'Lista de prioridades (placeholder)',
+    schema: { type: 'array', items: { type: 'string' }, example: ['baixa', 'media', 'alta'] },
+  })
+  getPrioridades() {
+    // Ajuste se houver enum real de prioridades no domínio
+    return ['baixa', 'media', 'alta']
+  }
+
+  @Get('tipos')
+  @Public()
+  @ApiOkResponse({
+    description: 'Lista de tipos (mapeado para status de tarefa por ora)',
+    schema: { type: 'array', items: { type: 'string', enum: Object.values(TaskStatus) } },
+  })
+  getTipos() {
+    // Ajuste quando existir enum/entidade de tipos específico
+    return Object.values(TaskStatus)
+  }
+}
+

--- a/src/meta/meta.controller.ts
+++ b/src/meta/meta.controller.ts
@@ -3,12 +3,14 @@ import { ApiBearerAuth, ApiOkResponse, ApiTags, ApiUnauthorizedResponse } from '
 import { ErrorResponseDto } from 'src/common/dto/error-response.dto';
 import { TaskStatus } from 'src/task/entities/task.entity';
 import { UserRole } from 'src/user/entities/user.entity';
+import { Public } from 'src/auth/public.decorator';
 
 @ApiTags('meta')
 @ApiBearerAuth('access-token')
 @Controller('meta')
 export class MetaController {
   @Get('enums/user-roles')
+  @Public()
   @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista de valores do enum UserRole',
@@ -19,6 +21,7 @@ export class MetaController {
   }
 
   @Get('enums/task-status')
+  @Public()
   @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Lista de valores do enum TaskStatus',
@@ -29,6 +32,7 @@ export class MetaController {
   }
 
   @Get('enums')
+  @Public()
   @ApiUnauthorizedResponse({ description: 'Não autenticado', type: ErrorResponseDto })
   @ApiOkResponse({
     description: 'Objeto com listas dos enums usados nos selects',

--- a/src/meta/meta.module.ts
+++ b/src/meta/meta.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MetaController } from './meta.controller';
+import { EnumsController } from './enums.controller';
+import { StatusController } from './status.controller';
 
 @Module({
-  controllers: [MetaController],
+  controllers: [MetaController, EnumsController, StatusController],
 })
 export class MetaModule {}
-

--- a/src/meta/status.controller.ts
+++ b/src/meta/status.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common'
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger'
+import { Public } from 'src/auth/public.decorator'
+
+@ApiTags('status')
+@Controller('status')
+export class StatusController {
+  @Get()
+  @Public()
+  @ApiOkResponse({ description: 'Status do serviço', schema: { type: 'object', properties: { status: { type: 'string', example: 'ok' } } } })
+  status() {
+    return { status: 'ok' }
+  }
+}
+

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,7 +9,7 @@ import type { Request } from 'express';
 
 @ApiTags('user')
 @ApiBearerAuth('access-token')
-@Controller('user')
+@Controller(['user', 'usuarios'])
 export class UserController {
   constructor(private readonly userService: UserService) { }
 
@@ -50,8 +50,13 @@ export class UserController {
   @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Itens por página', example: 10 })
   @ApiQuery({ name: 'sortBy', required: false, enum: ['id', 'name', 'email', 'role'], description: 'Campo para ordenação' })
   @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Direção da ordenação' })
-  findAll(@Query() query: QueryUserDto) {
-    return this.userService.findAll(query);
+  findAll(@Query() query: any) {
+    // alias perPage -> limit
+    const q: QueryUserDto = { ...query }
+    if (q && (q as any).perPage && !q.limit) {
+      q.limit = Number((q as any).perPage)
+    }
+    return this.userService.findAll(q);
   }
 
   @Get('id/:id')


### PR DESCRIPTION
- enableCors(origin: true, credentials: true)
- Aliases PT-BR: @Controller(['user','usuarios']), @Controller(['association','associacoes'])
- Suporte a perPage -> limit em listagens
- Endpoints publicos: GET /status, GET /enums/prioridades, GET /enums/tipos
- Marca endpoints de meta como @Public()